### PR TITLE
Fix the definition of the explicit controller definition

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -25,4 +25,6 @@ services:
 
     App\Controller\Hello:
         calls:
-            - [setContainer, ["@service_container"]]
+            - [setContainer, ["@Psr\Container\ContainerInterface"]]
+        tags:
+            - { name: 'container.service_subscriber' }


### PR DESCRIPTION
Note that in this case, the config could actually be removed, as autoconfiguration is actually enabled.